### PR TITLE
Дадаў яўна прапісаны дазвол на запіса у апісанне пайплана каб выправіць публікацыю файлаў ў рэлізе

### DIFF
--- a/.github/workflows/release-publishing.yml
+++ b/.github/workflows/release-publishing.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [ "published" ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Апісанне

Яўна прапісаў у канфігурацыі пайплайна публікацыі рэліза што гэтая задача мае права пісаць у рэпазітар. У выніку, публікацыя можа дадаваць створаныя бінарныя файлы да рэліза на Github.

## Праверкі

`nox`, публікацыя тэставага рэліза 2.0.2ф1

## Кантрольны спіс

- [X] Загаловак PR, які максімальна коратка і сцісла апісвае сутнасць зменаў.
- [ ] Усе складаныя і неадназначныя месцы ў кодзе маюць зразумелыя каментары
- [X] PR мае пазнаку (tag), якая паказвае сутнасць зменаў
