### PR TITLE
Дадаў Python 3.14 і прыбраў 3.9
Абнавіў версіі Github actions

### DIFF
--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -14,17 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
     - name: Install dependencies
       run: uv sync --dev
     - name: Test with the whole power of nox

--- a/.github/workflows/release-publishing.yml
+++ b/.github/workflows/release-publishing.yml
@@ -15,17 +15,17 @@ jobs:
     
     steps:
     
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - run: git checkout ${{github.sha}} 
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: 3.14
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
 
     - run: uv sync --no-editable
 
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"] 
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"] 
 
     steps:
     - name: Get tests and tests only
@@ -85,14 +85,14 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: 3.14
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
-    - uses: actions/download-artifact@v4
+      uses: astral-sh/setup-uv@v6
+    - uses: actions/download-artifact@v5
       with:
         name: packages
         path: dist
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Obtain artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: packages
           path: dist


### PR DESCRIPTION
## Апісанне

Прыбраў тэсты для версіі пітона 3.9, для якой скончылася падтрымка. Дадаў тэсты на 3.14, каторая недаўна выйшла.

Абнавіў версіі Github Actions.

Абнавіў інфармацыю пра пакет, з гэтага маоманту мы падтрымліваем Пітон ад версіі 3.10 і вышэй.

## Праверкі

Запуск тэстаў на тых версіях Python, каторыя падтрымліваюцца: https://github.com/latynkatar/latynkatar/actions/runs/18234193639

## Кантрольны спіс

- [X] Загаловак PR, які максімальна коратка і сцісла апісвае сутнасць зменаў.
- [ ] Усе складаныя і неадназначныя месцы ў кодзе маюць зразумелыя каментары
- [X] PR мае пазнаку (tag), якая паказвае сутнасць зменаў
