### PR TITLE
Направіў памылку ў напісанні ётаваных пасля ў. Дадаў тэст

### DIFF
--- a/src/latynkatar/converters/cyr_lat.py
+++ b/src/latynkatar/converters/cyr_lat.py
@@ -135,8 +135,7 @@ class CyrLatConverter(
         return (
             not self._previos_letters
             or self._previos_letters[-1].lower() in CYRRILIC_VOVELS
-            or self._previos_letters[-1].lower() in ("'", "ь")
-            or self._previos_letters[-1].lower() == "ł"
+            or self._previos_letters[-1].lower() in ("'", "ь", "ў")
         )
 
     def _convert_iotated(self) -> str:

--- a/tests/cyr_lat/test_vovels.py
+++ b/tests/cyr_lat/test_vovels.py
@@ -25,6 +25,11 @@ def test_ja():
     )
 
 
+def test_jotavanyja_pa_u_nieskladovyn():
+    """Тест на канвертацыю ётаваных па ў."""
+    assert latynkatar.CyrLatConverter("здароўе ШЧАЎЯ").convert() == "zdaroŭje ŠČAŬJA"
+
+
 def test_vialikija_litary():
     """Тест на розныя спалучэнні вялікіх і малых літар."""
     assert (


### PR DESCRIPTION
## Апісанне

Выпраўляе памылку ў канвертацыі ётаваных пасля ў. Цяпер атрымліваецца як належыць: ščaŭja zdaroŭje

## Праверкі

Дадаў тэст які правярае такое спалучэнне

## Кантрольны спіс

*Выдаліце непатрэбныя пункты, усё што тычыцца вашага PR мусіць быць зроблена і адзначана.*

- [X] Загаловак PR, які максімальна коратка і сцісла апісвае сутнасць зменаў.
- [ ] Усе складаныя і неадназначныя месцы ў кодзе маюць зразумелыя каментары
- [X] PR мае пазнаку (tag), якая паказвае сутнасць зменаў
