### PR TITLE
Выправіў параметр readme ў pyproject toml

### DIFF
--- a/.github/workflows/release-publishing.yml
+++ b/.github/workflows/release-publishing.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
     
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - run: git checkout ${{github.sha}} 
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: 3.14
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
     - run: uv sync --no-editable
 
@@ -38,11 +38,14 @@ jobs:
     - name: Remove files I don't want in build
       run: rm -rf tests/ .github/ noxfile.pl .envrc .gitignore uv.lock
 
+    - name: Generate README.md
+      run: nox -s compile_readme_in_markdown
+
     - name: Build the package
       run: uv build
 
     - name: Collect builded package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: packages
         path: dist/*
@@ -59,16 +62,16 @@ jobs:
 
     steps:
     - name: Get tests and tests only
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         sparse-checkout: |
           tests
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
 
     - uses: actions/download-artifact@v4
       with:
@@ -85,14 +88,14 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:
         python-version: 3.14
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
-    - uses: actions/download-artifact@v5
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+    - uses: actions/download-artifact@v8
       with:
         name: packages
         path: dist
@@ -107,7 +110,7 @@ jobs:
 
     steps:
       - name: Obtain artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: packages
           path: dist

--- a/.github/workflows/release-publishing.yml
+++ b/.github/workflows/release-publishing.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-    - run: uv sync --no-editable
+    - run: uv sync --dev --no-editable
 
     - name: Set version for the release tag
       run: uv run nox -s set_version -- ${{github.ref}}
@@ -39,7 +39,7 @@ jobs:
       run: rm -rf tests/ .github/ noxfile.pl .envrc .gitignore uv.lock
 
     - name: Generate README.md
-      run: nox -s compile_readme_in_markdown
+      run: uv run nox -s compile_readme_in_markdown
 
     - name: Build the package
       run: uv build

--- a/noxfile.py
+++ b/noxfile.py
@@ -150,3 +150,9 @@ def install_precommit(session):
         "post-checkout",
         external=True,
     )
+
+
+@nox.session
+def compile_readme_in_markdown(session):
+    """Кампілюе з README.adoc файл README ў фармаце Markdown."""
+    session.run("uvx", "--from", "Pydowndoc-bin", "--", "downdoc", "README.adoc")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 description = """EN: Simple and small package to convert belarussian cyrillic text to a modern (the one with ž, č, š and v) and old (the one with ż, cz, sz and w) lathin or from lathin to cyrillic.
 
 BE: Просты і невялікі пакет для канвертацыі беларускай кірыліцы ў сучасную (з ž, č, š і v) і старую (з ż, cz, sz і w) лацінку, ці з лацінкі ў кірыліцу."""
-readme = {file = "README.adoc", content-type = "text/asciidoc"}
+readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 description = """EN: Simple and small package to convert belarussian cyrillic text to a modern (the one with ž, č, š and v) and old (the one with ż, cz, sz and w) lathin or from lathin to cyrillic.
 
 BE: Просты і невялікі пакет для канвертацыі беларускай кірыліцы ў сучасную (з ž, č, š і v) і старую (з ż, cz, sz і w) лацінку, ці з лацінкі ў кірыліцу."""
-readme = "README.md"
+readme = {file = "README.adoc", content-type = "text/asciidoc"}
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Апісанне

Пасля міграцыі README з Markdown у AsciiDoc знікла магчымасць атрымаць поўнае апісанне пакета для PyPI. Гэтыя змены дадаюць да зборкі пакета кампіляцыю README у фармаце Markdown пад час зборкі пакета.

## Праверкі

Праз публікацыю пробнага пакета праз CI.

## Кантрольны спіс

- [X] Загаловак PR, які максімальна коратка і сцісла апісвае сутнасць зменаў.
- [ ] Усе складаныя і неадназначныя месцы ў кодзе маюць зразумелыя каментары
- [X] PR мае пазнаку (tag), якая паказвае сутнасць зменаў

Closes #126 
